### PR TITLE
Replaced make folder with makefile that's easier to use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+install:
+	sudo apt-get update
+	curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+	sudo apt-get install -y nodejs
+
+clean:
+	sudo apt-get purge nodejs
+	sudo apt-get autoremove

--- a/make/installs.sh
+++ b/make/installs.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-sudo apt-get update
-
-# Using Ubuntu
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-sudo apt-get install -y nodejs


### PR DESCRIPTION
Replaces make folder with makefile.

A makefile is easier to use, just simply run: `make`

To remove/uninstall the packages, just run `make clean`